### PR TITLE
fix crash due to unaligned memory access

### DIFF
--- a/DrZzs_LEDs_Pub.ino
+++ b/DrZzs_LEDs_Pub.ino
@@ -3,6 +3,8 @@
 #include <PubSubClient.h>
 #define FASTLED_INTERRUPT_RETRY_COUNT 0
 #include <FastLED.h>
+#define FL_ALIGN_PROGMEM  __attribute__ ((aligned (4)))
+
 
 #include <ArduinoOTA.h>
 #include <ESP8266mDNS.h>


### PR DESCRIPTION
The palettes need to be 4 byte aligned or will cause a crash when they are read into memory.

This is a workaround for a FastLED issue on ESP8266.

I created an issue in the FastLED repo:

https://github.com/FastLED/FastLED/issues/696